### PR TITLE
chore(deps): update store-devtools

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Stack
 - Angular 2
 - [ngrx/store](https://github.com/ngrx/store)
 - [ngrx/effects](https://github.com/ngrx/effects)
+- [ngrx/store-devtools](https://github.com/ngrx/store-devtools)
 - RxJS
 - SASS
 - Typescript 2

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "zone.js": "~0.6.23"
   },
   "devDependencies": {
-    "@ngrx/store-devtools": "~3.0.2",
+    "@ngrx/store-devtools": "~3.1.0",
     "@types/core-js": "~0.9.32",
     "@types/jasmine": "~2.2.33",
     "@types/node": "~6.0.38",

--- a/src/app/index.ts
+++ b/src/app/index.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { Routes, RouterModule } from '@angular/router';
 import { StoreModule } from '@ngrx/store';
+import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 
 import { TasksModule, taskReducer } from 'src/tasks';
 import { AppComponent } from './components/app';
@@ -26,6 +27,7 @@ const routes: Routes = [
     StoreModule.provideStore({
       tasks: taskReducer
     }),
+    StoreDevtoolsModule.instrumentOnlyWithExtension(),
     TasksModule
   ],
   providers: [


### PR DESCRIPTION
store-devtools 3.1.0 fixes incompatibility with Redux DevTools extension
